### PR TITLE
docs: Fix simple typo, hightlight -> highlight

### DIFF
--- a/public/admin/webarch/assets/js/form_validations.js
+++ b/public/admin/webarch/assets/js/form_validations.js
@@ -30,12 +30,12 @@ $(document).ready(function() {
                     parent.removeClass('success-control').addClass('error-control');  
                 },
 
-                highlight: function (element) { // hightlight error inputs
+                highlight: function (element) { // highlight error inputs
 					var parent = $(element).parent();
                     parent.removeClass('success-control').addClass('error-control'); 
                 },
 
-                unhighlight: function (element) { // revert the change done by hightlight
+                unhighlight: function (element) { // revert the change done by highlight
                     
                 },
 
@@ -81,12 +81,12 @@ $(document).ready(function() {
                     parent.removeClass('success-control').addClass('error-control');  
                 },
 
-                highlight: function (element) { // hightlight error inputs
+                highlight: function (element) { // highlight error inputs
 					var parent = $(element).parent();
                     parent.removeClass('success-control').addClass('error-control'); 
                 },
 
-                unhighlight: function (element) { // revert the change done by hightlight
+                unhighlight: function (element) { // revert the change done by highlight
                     
                 },
 
@@ -170,11 +170,11 @@ $(document).ready(function() {
 					$('<span class="error"></span>').insertAfter(element).append(label)
                 },
 
-                highlight: function (element) { // hightlight error inputs
+                highlight: function (element) { // highlight error inputs
 					
                 },
 
-                unhighlight: function (element) { // revert the change done by hightlight
+                unhighlight: function (element) { // revert the change done by highlight
                     
                 },
 

--- a/public/admin/webarch/assets/js/login.js
+++ b/public/admin/webarch/assets/js/login.js
@@ -23,11 +23,11 @@ $(document).ready(function() {
                     parent.removeClass('success-control').addClass('error-control');  
                 },
 
-                highlight: function (element) { // hightlight error inputs
+                highlight: function (element) { // highlight error inputs
 					
                 },
 
-                unhighlight: function (element) { // revert the change done by hightlight
+                unhighlight: function (element) { // revert the change done by highlight
                     
                 },
 

--- a/public/admin/webarch/assets/js/support_ticket.js
+++ b/public/admin/webarch/assets/js/support_ticket.js
@@ -38,12 +38,12 @@ $('#new-ticket-form').validate({
                     parent.removeClass('success-control').addClass('error-control');  
                 },
 
-                highlight: function (element) { // hightlight error inputs
+                highlight: function (element) { // highlight error inputs
                     var parent = $(element).parent();
                     parent.removeClass('success-control').addClass('error-control'); 
                 },
 
-                unhighlight: function (element) { // revert the change done by hightlight
+                unhighlight: function (element) { // revert the change done by highlight
                     
                 },
 


### PR DESCRIPTION
There is a small typo in public/admin/webarch/assets/js/form_validations.js, public/admin/webarch/assets/js/login.js, public/admin/webarch/assets/js/support_ticket.js.

Should read `highlight` rather than `hightlight`.

